### PR TITLE
Fix static directory nesting in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,6 +102,7 @@ jobs:
           mv website-core/history ./history 2>/dev/null || true
           mv website-core/index.html ./
           mv website-core/zh.html ./ 2>/dev/null || true
+          rm -rf ./static
           mv website-core/static ./static
           rm -rf website-core
       - name: Push analysis report to history branch


### PR DESCRIPTION
This PR adds `rm -rf ./static` before moving `website-core/static` to prevent the `static/static` nesting issue.