### PR TITLE
Fix Chinese site path in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           mv website-core/history ./history 2>/dev/null || true
           mv website-core/index.html ./
-          mv website-core/zh.html ./ 2>/dev/null || true
+          mv website-core/cn ./cn 2>/dev/null || true
           rm -rf ./static
           mv website-core/static ./static
           rm -rf website-core


### PR DESCRIPTION
The Chinese site generates files in the `cn` directory, not as `zh.html`. This PR correctly moves the `cn` directory during deployment so that `/cn/` resolves properly.