### PR TITLE
Deploy generated API files to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,6 +111,8 @@ jobs:
           mv website-core/au ./au 2>/dev/null || true
           rm -rf ./static
           mv website-core/static ./static
+          rm -rf ./api
+          mv website-core/api ./api 2>/dev/null || true
           rm -rf website-core
       - name: Push analysis report to history branch
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
This PR updates the deploy workflow so that the newly added API files generated in website-core (PR #5) are correctly moved to the `api` directory and published to GitHub Pages.