### PR TITLE
fix: ensure history directory exists for actions-gh-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,7 +105,11 @@ jobs:
           python generate_site_au.py
       - name: Move generated artifacts
         run: |
-          mv website-core/history ./history 2>/dev/null || true
+          if [ -d "website-core/history" ]; then
+            mv website-core/history ./history
+          else
+            mkdir -p ./history
+          fi
           mv website-core/index.html ./
           mv website-core/cn ./cn 2>/dev/null || true
           mv website-core/au ./au 2>/dev/null || true


### PR DESCRIPTION
Fixes ENOENT error during deployment when history directory is not generated by creating an empty directory instead.