### PR TITLE
fix: expose Gemini key to site generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,18 +88,21 @@ jobs:
           MARKETAUX_API_KEY: ${{ secrets.MARKETAUX_API_KEY }}
           GNEWS_API_KEY: ${{ secrets.GNEWS_API_KEY }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
           cd website-core
           python generate_site.py
       - name: Generate Chinese site
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
           cd website-core
           python generate_site_cn.py
       - name: Generate Australian site
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
           cd website-core
           python generate_site_au.py


### PR DESCRIPTION
## Summary

- expose the existing `GEMINI_API_KEY` repository secret to Global site generation
- expose the same secret to Chinese and Australian site generation so all financial-analysis fallbacks can use Gemini

## Verification

- confirmed the `GEMINI_API_KEY` repository secret exists
- parsed `.github/workflows/deploy.yml` successfully as YAML
- `git diff --check`