### PR TITLE
feat: Docker image for local deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# =============================================================================
+# .dockerignore — Files excluded from the Docker build context
+# =============================================================================
+.git
+.github
+.gitignore
+.actrc
+.env
+.env.local
+.secrets
+.venv-deploy/
+.venv/
+website-core
+__pycache__
+*.pyc
+node_modules
+history/
+cn/
+au/
+static/
+api/
+*.log
+.DS_Store
+LICENSE
+README.md
+CNAME

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,55 @@
+# =============================================================================
+# Waneye Docker Deploy — Environment Variables
+# =============================================================================
+# Copy this file to .env.local and fill in your API keys:
+#   cp .env.local.example .env.local
+#
+# This file is loaded by `make deploy` via Docker's --env-file flag.
+# Never commit .env.local to git!
+# =============================================================================
+
+# ── Required for site generation ─────────────────────────────────────────────
+
+# OpenAI API key — used for AI-powered financial analysis
+OPENAI_API_KEY=sk-your-openai-key-here
+
+# News API key — fetches financial news headlines
+NEWSAPI_API_KEY=your-newsapi-key-here
+
+# Financial Modeling Prep API key — financial data and rates
+FMP_API_KEY=your-fmp-key-here
+
+# Marketaux API key — market news and sentiment
+MARKETAUX_API_KEY=your-marketaux-key-here
+
+# GNews API key — additional news source
+GNEWS_API_KEY=your-gnews-key-here
+
+# DeepSeek API key — used for analysis generation and translations
+DEEPSEEK_API_KEY=your-deepseek-key-here
+
+# Gemini API key — used for analysis generation and translations
+GEMINI_API_KEY=your-gemini-key-here
+
+# ── Required for Docker deploy ───────────────────────────────────────────────
+
+# GitHub Personal Access Token — needed to clone the private website-core repo
+# and push to gh-pages/history branches from the container.
+GH_PAT=ghp_your-github-pat-here
+
+# ── Optional ─────────────────────────────────────────────────────────────────
+
+# Ollama — the container auto-connects to Ollama on the host via
+# host.docker.internal:11434. Override these only if needed.
+# OLLAMA_HOST=http://host.docker.internal:11434/v1
+# OLLAMA_MODEL=qwen3.8:27b-mlx
+
+# Skip regional site generation
+# SKIP_CN=true
+# SKIP_AU=true
+
+# Build only, don't push to gh-pages
+# SKIP_DEPLOY=true
+
+# Use test mode for faster builds (limited data)
+# TEST_MODE=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,104 @@
+# =============================================================================
+# Waneye Deploy — Docker image for local deployment
+# =============================================================================
+# Replicates the deploy.yml GitHub Actions workflow in a container.
+#
+# Build:  make build
+# Run:    make deploy
+#
+# The container:
+#   - Clones website-core (via GH_PAT) or uses a mounted copy
+#   - Fetches existing images from gh-pages
+#   - Generates all site variants (global, cn, au)
+#   - Deploys to gh-pages and history branches
+#   - Exits when done
+#
+# Ollama access:
+#   On macOS Docker Desktop, host.docker.internal is available by default.
+#   The entrypoint sets OLLAMA_HOST=http://host.docker.internal:11434/v1
+#   so the container can reach Ollama running on the host.
+# =============================================================================
+
+FROM ubuntu:24.04
+
+LABEL maintainer="waneyetechnology" \
+      description="Waneye deploy workflow runner"
+
+# Avoid interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# ── System dependencies ──────────────────────────────────────────────────────
+# Ubuntu 24.04 ships Python 3.12; add deadsnakes PPA for Python 3.11 to match
+# the deploy.yml workflow that uses actions/setup-python with python 3.11.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    # Python 3.11 (matching deploy.yml)
+    python3.11 \
+    python3.11-venv \
+    python3.11-distutils \
+    python3-pip \
+    # Git (needed for cloning repos and deploying to gh-pages)
+    git \
+    # curl (for health checks, e.g. Ollama)
+    curl \
+    # Playwright system dependencies (matching deploy.yml)
+    libnss3 \
+    libatk-bridge2.0-0 \
+    libdrm2 \
+    libxkbcommon0 \
+    libgtk-3-0 \
+    libgbm1 \
+    libasound2t64 \
+    libxrandr2 \
+    libxss1 \
+    # Additional deps often needed by Playwright/Chromium
+    libx11-xcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxcb-dri3-0 \
+    libpango-1.0-0 \
+    libcairo2 \
+    libcups2 \
+    libatspi2.0-0 \
+    fonts-liberation \
+    xdg-utils \
+    # Clean up
+    && rm -rf /var/lib/apt/lists/*
+
+# Make python3.11 the default python/python3
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
+
+# ── Python virtual environment ───────────────────────────────────────────────
+# Use a venv to avoid conflicts with the system Python 3.12 setuptools.
+RUN python3.11 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# ── Install Python dependencies ─────────────────────────────────────────────
+# Copy requirements first for better Docker layer caching.
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
+    pip install --no-cache-dir -r /tmp/requirements.txt && \
+    rm /tmp/requirements.txt
+
+# ── Install Playwright Chromium ──────────────────────────────────────────────
+RUN playwright install chromium
+
+# ── Working directory ────────────────────────────────────────────────────────
+WORKDIR /workspace
+
+# ── Git configuration (for deploy commits) ───────────────────────────────────
+RUN git config --global user.name "docker-deploy[bot]" && \
+    git config --global user.email "docker-deploy[bot]@users.noreply.github.com" && \
+    git config --global --add safe.directory /workspace && \
+    git config --global --add safe.directory /workspace/website
+
+# ── Entrypoint script ───────────────────────────────────────────────────────
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ DOCKER_RUN_OPTS := \
 
 # ── Targets ──────────────────────────────────────────────────────────────────
 
-.PHONY: build deploy deploy-test deploy-dry clean help
+.PHONY: build deploy deploy-test deploy-dry setup-cron clean help
 
 ## Build the Docker image
 build:
@@ -70,6 +70,10 @@ deploy-dry: _check-env _check-core
 		-v "$(CORE_PATH):/workspace/website-core:ro" \
 		$(FULL_IMAGE)
 
+## Set up an hourly cron job to run deploy
+setup-cron:
+	@./setup-cron.sh
+
 ## Remove the Docker image
 clean:
 	@echo "🗑  Removing $(FULL_IMAGE)..."
@@ -86,6 +90,7 @@ help:
 	@echo "  make deploy        Run the full deploy workflow"
 	@echo "  make deploy-test   Run in test mode (faster)"
 	@echo "  make deploy-dry    Build only, skip gh-pages push"
+	@echo "  make setup-cron    Set up an hourly cron job for deploy"
 	@echo "  make clean         Remove the Docker image"
 	@echo "  make help          Show this help"
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,121 @@
+# =============================================================================
+# Waneye Deploy — Makefile
+# =============================================================================
+# Usage:
+#   make build         Build the Docker image
+#   make deploy        Run the full deploy workflow in Docker
+#   make deploy-test   Run in test mode (faster, limited data)
+#   make deploy-dry    Build only, skip pushing to gh-pages
+#   make clean         Remove the Docker image
+#   make help          Show available targets
+# =============================================================================
+
+# ── Configuration ────────────────────────────────────────────────────────────
+IMAGE_NAME   := waneye-deploy
+IMAGE_TAG    := latest
+FULL_IMAGE   := $(IMAGE_NAME):$(IMAGE_TAG)
+
+# Environment file for API keys and secrets
+ENV_FILE     := .env.local
+
+# Path to website-core repo (mounted read-only into the container)
+CORE_PATH    ?= $(shell cd .. && pwd)/website-core
+
+# ── Docker run options ───────────────────────────────────────────────────────
+# --add-host: Ensure the container can reach the host (for Ollama)
+# --rm: Auto-remove the container when it exits
+# --env-file: Load API keys from .env.local
+DOCKER_RUN_OPTS := \
+	--rm \
+	--add-host=host.docker.internal:host-gateway \
+	--env-file $(ENV_FILE)
+
+# ── Targets ──────────────────────────────────────────────────────────────────
+
+.PHONY: build deploy deploy-test deploy-dry clean help
+
+## Build the Docker image
+build:
+	@echo ""
+	@echo "🐳 Building $(FULL_IMAGE)..."
+	@echo ""
+	docker build -t $(FULL_IMAGE) .
+
+## Run the full deploy workflow (generates + deploys to gh-pages)
+deploy: _check-env _check-core
+	@echo ""
+	@echo "🚀 Running deploy workflow in Docker..."
+	@echo ""
+	docker run $(DOCKER_RUN_OPTS) \
+		-v "$(CORE_PATH):/workspace/website-core:ro" \
+		$(FULL_IMAGE)
+
+## Run deploy in test mode (faster, limited data)
+deploy-test: _check-env _check-core
+	@echo ""
+	@echo "🧪 Running deploy workflow in test mode..."
+	@echo ""
+	docker run $(DOCKER_RUN_OPTS) \
+		-e TEST_MODE=true \
+		-v "$(CORE_PATH):/workspace/website-core:ro" \
+		$(FULL_IMAGE)
+
+## Build only — skip pushing to gh-pages (dry run)
+deploy-dry: _check-env _check-core
+	@echo ""
+	@echo "🔨 Running build-only (no deploy)..."
+	@echo ""
+	docker run $(DOCKER_RUN_OPTS) \
+		-e SKIP_DEPLOY=true \
+		-v "$(CORE_PATH):/workspace/website-core:ro" \
+		$(FULL_IMAGE)
+
+## Remove the Docker image
+clean:
+	@echo "🗑  Removing $(FULL_IMAGE)..."
+	-docker rmi $(FULL_IMAGE) 2>/dev/null
+	@echo "Done."
+
+## Show help
+help:
+	@echo ""
+	@echo "Waneye Deploy — Docker Targets"
+	@echo "════════════════════════════════════════════════"
+	@echo ""
+	@echo "  make build         Build the Docker image"
+	@echo "  make deploy        Run the full deploy workflow"
+	@echo "  make deploy-test   Run in test mode (faster)"
+	@echo "  make deploy-dry    Build only, skip gh-pages push"
+	@echo "  make clean         Remove the Docker image"
+	@echo "  make help          Show this help"
+	@echo ""
+	@echo "Configuration:"
+	@echo "  ENV_FILE    = $(ENV_FILE)"
+	@echo "  CORE_PATH   = $(CORE_PATH)"
+	@echo "  IMAGE       = $(FULL_IMAGE)"
+	@echo ""
+	@echo "Environment variables (set in $(ENV_FILE)):"
+	@echo "  SKIP_CN=true       Skip Chinese site generation"
+	@echo "  SKIP_AU=true       Skip Australian site generation"
+	@echo "  SKIP_DEPLOY=true   Skip pushing to gh-pages"
+	@echo "  TEST_MODE=true     Use --test-mode for faster builds"
+	@echo ""
+
+# ── Internal checks ─────────────────────────────────────────────────────────
+_check-env:
+	@if [ ! -f "$(ENV_FILE)" ]; then \
+		echo "❌ $(ENV_FILE) not found!"; \
+		echo "   Create it from the template:"; \
+		echo "   cp .env.local.example .env.local"; \
+		echo "   Then fill in your API keys."; \
+		exit 1; \
+	fi
+
+_check-core:
+	@if [ ! -d "$(CORE_PATH)" ]; then \
+		echo "❌ website-core not found at: $(CORE_PATH)"; \
+		echo "   Clone it first:"; \
+		echo "   git clone git@github.com:waneyetechnology/website-core.git $(CORE_PATH)"; \
+		echo "   Or set CORE_PATH: make deploy CORE_PATH=/path/to/website-core"; \
+		exit 1; \
+	fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -252,16 +252,7 @@ else
     HISTORY_TMP=$(mktemp -d)
     cp -R ./history/* "$HISTORY_TMP/" 2>/dev/null || true
 
-    # Check if history branch exists
-    if git ls-remote --heads origin history | grep -q history; then
-      git fetch origin history:history 2>/dev/null || true
-      git worktree add "$HISTORY_TMP/.wt" history 2>/dev/null || {
-        # Fallback: push as orphan
-        warn "Worktree failed, using alternative deploy method"
-      }
-    fi
-
-    # Simple approach: use a temporary orphan commit
+    # Simple approach: initialize a new repo in the temp dir and fetch history
     cd "$HISTORY_TMP"
     git init
     git config user.name "docker-deploy[bot]"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# =============================================================================
+# docker-entrypoint.sh — Runs the Waneye deploy workflow inside the container
+#
+# This script replicates the deploy.yml GitHub Actions workflow steps:
+#   1. Clone/link website-core
+#   2. Fetch existing images from gh-pages
+#   3. Generate main site (generate_site.py)
+#   4. Generate Chinese site (generate_site_cn.py)
+#   5. Generate Australian site (generate_site_au.py)
+#   6. Move generated artifacts
+#   7. Push history branch
+#   8. Deploy to gh-pages
+#
+# Environment variables:
+#   GH_PAT            — GitHub Personal Access Token (required for clone & push)
+#   OPENAI_API_KEY    — Required for main site generation
+#   NEWSAPI_API_KEY   — Required for main site generation
+#   FMP_API_KEY       — Required for main site generation
+#   MARKETAUX_API_KEY — Required for main site generation
+#   GNEWS_API_KEY     — Required for main site generation
+#   DEEPSEEK_API_KEY  — Required for site generation
+#   GEMINI_API_KEY    — Required for site generation
+#   OLLAMA_HOST       — Optional, defaults to http://host.docker.internal:11434/v1
+#   OLLAMA_MODEL      — Optional, Ollama model to use
+#   SKIP_CN           — Set to "true" to skip Chinese site generation
+#   SKIP_AU           — Set to "true" to skip Australian site generation
+#   SKIP_DEPLOY       — Set to "true" to skip pushing to gh-pages (build only)
+#   TEST_MODE         — Set to "true" to use --test-mode for faster builds
+# =============================================================================
+set -euo pipefail
+
+# ─── Colors & helpers ────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+step_num=0
+
+step() {
+  step_num=$((step_num + 1))
+  echo ""
+  echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+  echo -e "${BOLD}${CYAN}  Step ${step_num}: $1${NC}"
+  echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+}
+
+info()    { echo -e "${CYAN}ℹ ${NC} $1"; }
+success() { echo -e "${GREEN}✅${NC} $1"; }
+warn()    { echo -e "${YELLOW}⚠️ ${NC} $1"; }
+error()   { echo -e "${RED}❌${NC} $1"; }
+
+# ─── Banner ──────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${BOLD}${GREEN}╔══════════════════════════════════════════════════════════╗${NC}"
+echo -e "${BOLD}${GREEN}║      🐳 Waneye Docker Deploy                           ║${NC}"
+echo -e "${BOLD}${GREEN}╚══════════════════════════════════════════════════════════╝${NC}"
+echo ""
+
+# ─── Defaults ────────────────────────────────────────────────────────────────
+SKIP_CN="${SKIP_CN:-false}"
+SKIP_AU="${SKIP_AU:-false}"
+SKIP_DEPLOY="${SKIP_DEPLOY:-false}"
+TEST_MODE="${TEST_MODE:-false}"
+TEST_MODE_FLAG=""
+if [[ "$TEST_MODE" == "true" ]]; then
+  TEST_MODE_FLAG="--test-mode"
+fi
+
+# ─── Ollama: point to host by default ────────────────────────────────────────
+if [[ -z "${OLLAMA_HOST:-}" ]]; then
+  export OLLAMA_HOST="http://host.docker.internal:11434/v1"
+fi
+info "OLLAMA_HOST=${OLLAMA_HOST}"
+
+# Check if Ollama is reachable
+OLLAMA_URL="${OLLAMA_HOST%/v1}"  # strip /v1 suffix for the version check
+OLLAMA_URL="${OLLAMA_URL%/}"     # strip trailing slash
+if curl -sf --max-time 5 "${OLLAMA_URL}/api/version" &>/dev/null; then
+  success "Ollama is reachable at ${OLLAMA_HOST}"
+else
+  warn "Ollama not reachable at ${OLLAMA_HOST} — Ollama fallback will be unavailable"
+fi
+
+echo -e "  Skip CN:    ${BOLD}${SKIP_CN}${NC}"
+echo -e "  Skip AU:    ${BOLD}${SKIP_AU}${NC}"
+echo -e "  Skip Deploy:${BOLD}${SKIP_DEPLOY}${NC}"
+echo -e "  Test mode:  ${BOLD}${TEST_MODE}${NC}"
+echo ""
+
+# ─── Step: Validate secrets ──────────────────────────────────────────────────
+step "Validating environment"
+
+REQUIRED_KEYS=(
+  OPENAI_API_KEY
+  NEWSAPI_API_KEY
+  FMP_API_KEY
+  MARKETAUX_API_KEY
+  GNEWS_API_KEY
+  DEEPSEEK_API_KEY
+  GEMINI_API_KEY
+  GH_PAT
+)
+missing_keys=()
+for key in "${REQUIRED_KEYS[@]}"; do
+  if [[ -z "${!key:-}" ]]; then
+    missing_keys+=("$key")
+  else
+    val="${!key}"
+    info "${key} = ${val:0:8}..."
+  fi
+done
+
+if [[ ${#missing_keys[@]} -gt 0 ]]; then
+  error "Missing required environment variables:"
+  for key in "${missing_keys[@]}"; do
+    echo -e "  ${RED}✗${NC} ${key}"
+  done
+  echo ""
+  error "Ensure all required variables are set in your .env.local file."
+  exit 1
+fi
+success "All required environment variables present"
+
+# ─── Step: Set up website-core (writable copy) ──────────────────────────────
+step "Setting up website-core"
+
+CORE_SRC="/workspace/website-core"
+CORE_WORK="/workspace/_website-core-work"
+
+if [[ -d "$CORE_SRC" ]]; then
+  info "website-core mounted at ${CORE_SRC} — creating writable copy..."
+  cp -R "$CORE_SRC" "$CORE_WORK"
+  success "Writable copy created at ${CORE_WORK}"
+else
+  info "Cloning website-core from GitHub..."
+  git clone --depth 1 "https://${GH_PAT}@github.com/waneyetechnology/website-core.git" "$CORE_WORK"
+  success "website-core cloned"
+fi
+
+# ─── Step: Set up the website repo ──────────────────────────────────────────
+step "Setting up website repo"
+
+info "Cloning website repo for deploy context..."
+git clone --depth 1 "https://${GH_PAT}@github.com/waneyetechnology/website.git" /workspace/website
+cd /workspace/website
+
+# Link the writable website-core copy
+ln -s "$CORE_WORK" website-core
+info "Linked website-core into website directory"
+
+# ─── Step: Fetch existing images from gh-pages ──────────────────────────────
+step "Fetching existing images from gh-pages"
+
+if git ls-remote --heads origin gh-pages 2>/dev/null | grep -q gh-pages; then
+  info "Fetching gh-pages branch..."
+  git fetch origin gh-pages:gh-pages 2>/dev/null || git fetch origin gh-pages 2>/dev/null || true
+
+  if git show gh-pages:static/images/ &>/dev/null; then
+    info "Extracting images from gh-pages..."
+    mkdir -p website-core/static/images
+
+    git checkout gh-pages -- static/images/ 2>/dev/null || true
+
+    if [[ -d "static/images" ]]; then
+      image_count=$(find static/images -type f \( -name "*.jpg" -o -name "*.png" -o -name "*.webp" \) | wc -l | tr -d ' ')
+      info "Restored ${image_count} existing images"
+      cp -n static/images/* website-core/static/images/ 2>/dev/null || true
+      rm -rf static/images
+      success "Images restored to website-core/static/images/"
+    fi
+  else
+    info "No images directory in gh-pages yet"
+  fi
+else
+  info "gh-pages branch doesn't exist yet — starting fresh"
+fi
+
+# ─── Step: Generate main site ────────────────────────────────────────────────
+step "Generating main site (generate_site.py)"
+
+cd website-core
+python generate_site.py $TEST_MODE_FLAG
+cd ..
+success "Main site generated"
+
+# ─── Step: Generate Chinese site ─────────────────────────────────────────────
+if [[ "$SKIP_CN" != "true" ]]; then
+  step "Generating Chinese site (generate_site_cn.py)"
+  cd website-core
+  python generate_site_cn.py $TEST_MODE_FLAG
+  cd ..
+  success "Chinese site generated"
+else
+  step "Skipping Chinese site generation (SKIP_CN=true)"
+fi
+
+# ─── Step: Generate Australian site ─────────────────────────────────────────
+if [[ "$SKIP_AU" != "true" ]]; then
+  step "Generating Australian site (generate_site_au.py)"
+  cd website-core
+  python generate_site_au.py $TEST_MODE_FLAG
+  cd ..
+  success "Australian site generated"
+else
+  step "Skipping Australian site generation (SKIP_AU=true)"
+fi
+
+# ─── Step: Move generated artifacts ─────────────────────────────────────────
+step "Moving generated artifacts"
+
+mv website-core/history ./history 2>/dev/null || true
+mv website-core/index.html ./
+mv website-core/cn ./cn 2>/dev/null || true
+mv website-core/au ./au 2>/dev/null || true
+rm -rf ./static
+mv website-core/static ./static
+rm -rf ./api
+mv website-core/api ./api 2>/dev/null || true
+
+success "Artifacts moved"
+
+# Show what was generated
+echo ""
+[[ -f "./index.html" ]] && echo -e "  ${GREEN}✓${NC} index.html"
+[[ -d "./cn" ]]         && echo -e "  ${GREEN}✓${NC} cn/"
+[[ -d "./au" ]]         && echo -e "  ${GREEN}✓${NC} au/"
+[[ -d "./static" ]]     && echo -e "  ${GREEN}✓${NC} static/"
+[[ -d "./api" ]]        && echo -e "  ${GREEN}✓${NC} api/"
+[[ -d "./history" ]]    && echo -e "  ${GREEN}✓${NC} history/"
+echo ""
+
+# ─── Step: Deploy ────────────────────────────────────────────────────────────
+if [[ "$SKIP_DEPLOY" == "true" ]]; then
+  step "Skipping deploy (SKIP_DEPLOY=true)"
+  info "Build completed — generated files are in the container."
+  info "To extract: docker cp <container>:/workspace/website/ ."
+else
+  # Configure git for pushing
+  git remote set-url origin "https://${GH_PAT}@github.com/waneyetechnology/website.git" 2>/dev/null || true
+
+  # ── Deploy history branch ──
+  step "Deploying to history branch"
+  if [[ -d "./history" ]]; then
+    info "Pushing history/ to history branch..."
+
+    # Create a temporary directory for the history deploy
+    HISTORY_TMP=$(mktemp -d)
+    cp -R ./history/* "$HISTORY_TMP/" 2>/dev/null || true
+
+    # Check if history branch exists
+    if git ls-remote --heads origin history | grep -q history; then
+      git fetch origin history:history 2>/dev/null || true
+      git worktree add "$HISTORY_TMP/.wt" history 2>/dev/null || {
+        # Fallback: push as orphan
+        warn "Worktree failed, using alternative deploy method"
+      }
+    fi
+
+    # Simple approach: use a temporary orphan commit
+    cd "$HISTORY_TMP"
+    git init
+    git config user.name "docker-deploy[bot]"
+    git config user.email "docker-deploy[bot]@users.noreply.github.com"
+    git remote add origin "https://${GH_PAT}@github.com/waneyetechnology/website.git"
+
+    # Try to fetch existing history branch to keep files
+    git fetch origin history 2>/dev/null && git checkout -b history origin/history 2>/dev/null || git checkout -b history
+
+    # Copy new history files
+    cp -R /workspace/website/history/* . 2>/dev/null || true
+    git add -A
+    git commit -m "history: docker deploy $(date +%Y%m%d-%H%M%S)" --allow-empty
+    git push origin history --force
+    cd /workspace/website
+    rm -rf "$HISTORY_TMP"
+
+    success "History branch updated"
+  else
+    info "No history/ directory to deploy"
+  fi
+
+  # Remove history before gh-pages deploy
+  step "Removing history folder before site deploy"
+  rm -rf history
+
+  # ── Deploy to gh-pages ──
+  step "Deploying to gh-pages"
+  info "Pushing site to gh-pages branch..."
+
+  # Use a clean temporary directory for gh-pages deploy
+  DEPLOY_TMP=$(mktemp -d)
+  # Copy all site files (excluding .git and website-core)
+  for item in index.html cn au static api robots.txt sitemap.xml structured-data.json CNAME _config.yml LICENSE; do
+    if [[ -e "$item" ]]; then
+      cp -R "$item" "$DEPLOY_TMP/"
+    fi
+  done
+
+  cd "$DEPLOY_TMP"
+  git init
+  git config user.name "docker-deploy[bot]"
+  git config user.email "docker-deploy[bot]@users.noreply.github.com"
+  git remote add origin "https://${GH_PAT}@github.com/waneyetechnology/website.git"
+  git checkout -b gh-pages
+  git add -A
+  git commit -m "deploy: docker build $(date +%Y%m%d-%H%M%S)"
+  git push origin gh-pages --force
+  cd /workspace/website
+  rm -rf "$DEPLOY_TMP"
+
+  success "Deployed to gh-pages!"
+fi
+
+# ─── Done ────────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${BOLD}${GREEN}╔══════════════════════════════════════════════════════════╗${NC}"
+echo -e "${BOLD}${GREEN}║          ✅ Docker deploy completed successfully!       ║${NC}"
+echo -e "${BOLD}${GREEN}╚══════════════════════════════════════════════════════════╝${NC}"
+echo ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+# =============================================================================
+# Python requirements for the Docker deploy image
+# =============================================================================
+# These mirror website-core/requirements.txt.
+# Keep in sync when website-core dependencies change.
+# =============================================================================
+requests==2.31.0
+openai==1.93.0
+playwright==1.62.0
+csscompressor==0.9.5
+jsmin==3.0.0
+beautifulsoup4==4.12.3
+Pillow==11.0.0
+Jinja2==3.1.4

--- a/setup-cron.sh
+++ b/setup-cron.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# =============================================================================
+# setup-cron.sh — Set up an hourly cron job to run the Docker deploy
+# =============================================================================
+set -euo pipefail
+
+# ─── Colors & helpers ────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+# ─── Configuration ────────────────────────────────────────────────────────────
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOG_FILE="${REPO_DIR}/deploy-cron.log"
+CRON_SCHEDULE="0 * * * *"
+MARKER="WANEYE_DOCKER_DEPLOY_CRON"
+
+# Add common bin paths to ensure docker and make are found in cron's limited PATH
+CRON_CMD="PATH=/usr/local/bin:/opt/homebrew/bin:\$PATH cd ${REPO_DIR} && make deploy >> ${LOG_FILE} 2>&1 # ${MARKER}"
+
+echo -e "${CYAN}Setting up hourly cron job for Waneye deploy...${NC}"
+
+# Check if crontab is available
+if ! command -v crontab &> /dev/null; then
+    echo -e "${RED}❌ crontab command not found. Cron may not be supported on this system.${NC}"
+    exit 1
+fi
+
+TMP_CRON=$(mktemp)
+trap 'rm -f "$TMP_CRON"' EXIT
+
+# Export current crontab, excluding any previous version of our job
+crontab -l 2>/dev/null | grep -v "${MARKER}" > "$TMP_CRON" || true
+
+# Add the new cron job
+echo "${CRON_SCHEDULE} ${CRON_CMD}" >> "$TMP_CRON"
+
+# Install the new crontab
+crontab "$TMP_CRON"
+
+echo -e "${GREEN}✅ Cron job installed successfully!${NC}"
+echo -e "It will run hourly at the top of the hour (0 * * * *)."
+echo -e "Log file: ${LOG_FILE}"
+echo ""
+echo -e "To view your crontab, run: ${CYAN}crontab -l${NC}"
+echo -e "To remove this job later, edit your crontab manually: ${CYAN}crontab -e${NC}"


### PR DESCRIPTION
## Summary

Adds a Docker-based local deploy workflow that replicates the `deploy.yml` GitHub Actions pipeline in a container.

## Usage

```bash
# 1. Set up environment variables
cp .env.local.example .env.local
# Fill in API keys (including GH_PAT)

# 2. Build the Docker image
make build

# 3. Run the full deploy
make deploy

# 4. Or run in test mode (faster, limited data)
make deploy-test

# 5. Or build-only without deploying to gh-pages
make deploy-dry
```

## New Files

| File | Description |
|------|-------------|
| `Dockerfile` | Ubuntu 24.04 + Python 3.11 + Playwright + system deps |
| `docker-entrypoint.sh` | Entrypoint that runs the full deploy pipeline |
| `Makefile` | `make build` / `make deploy` / `make deploy-test` / `make deploy-dry` |
| `requirements.txt` | Python deps for Docker image (mirrors website-core) |
| `.dockerignore` | Minimize Docker build context |
| `.env.local.example` | Template for API keys and configuration |

## Features

- **Ollama access**: Container connects to Ollama on the host via `host.docker.internal:11434`
- **Read-only mount**: Mounts `website-core` read-only, creates writable copy inside container
- **Configurable**: Supports `SKIP_CN`, `SKIP_AU`, `SKIP_DEPLOY`, `TEST_MODE` env vars
- **Ephemeral**: Container exits after deployment completes (`--rm` flag)
- **Full pipeline**: Deploys to both `gh-pages` and `history` branches

## Architecture

```
Host (macOS)                    Docker Container
┌─────────────────────┐         ┌─────────────────────────────┐
│ .env.local (secrets) │──────▶ │ ENV vars loaded via         │
│                      │        │ --env-file                   │
│ website-core/ (:ro)  │──────▶ │ /workspace/website-core     │
│                      │        │   └─▶ writable copy created  │
│ Ollama :11434        │◀──────│ host.docker.internal:11434   │
└─────────────────────┘         │                              │
                                │ 1. Clone website repo        │
                                │ 2. Fetch gh-pages images     │
                                │ 3. Generate sites (en/cn/au) │
                                │ 4. Deploy to gh-pages        │
                                │ 5. Exit                      │
                                └─────────────────────────────┘
```

## Updates
- Added `setup-cron.sh` (and `make setup-cron`) to easily schedule the deployment to run hourly via local cron, compatible with both macOS and Linux.